### PR TITLE
Implements parallel dependency checking via Coroutines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ repositories {
 dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compile 'com.google.code.gson:gson:2.8.5'
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.2'
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core-common:1.2.2'
 }
 
 compileKotlin {

--- a/src/main/kotlin/pl/pszklarska/pubversionchecker/PubPackagesInspection.kt
+++ b/src/main/kotlin/pl/pszklarska/pubversionchecker/PubPackagesInspection.kt
@@ -5,7 +5,7 @@ import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
-
+import kotlinx.coroutines.runBlocking
 
 class PubPackagesInspection : LocalInspectionTool() {
 
@@ -41,11 +41,14 @@ class YamlElementVisitor(
     override fun visitFile(file: PsiFile) {
         if (!isOnTheFly) return
 
-        val fileParser = FileParser(file, dependencyChecker)
-        val problemDescriptions = fileParser.checkFile()
+        runBlocking {
 
-        problemDescriptions.forEach {
-            holder.showProblem(file, it.counter, it.currentVersion, it.latestVersion)
+            val fileParser = FileParser(file, dependencyChecker)
+            val problemDescriptions = fileParser.checkFile()
+
+            problemDescriptions.forEach {
+                holder.showProblem(file, it.counter, it.currentVersion, it.latestVersion)
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #7 

This massively speeds up checking of dependencies if they are not cached (e.g. the first time opening a project).

On a sample project with ~20 dependencies this only takes a second or 2 where as previously the UI would hang for 10+ seconds.

While this mostly fixes the problem, it's not the correct fix - I think the checking of dependencies needs to be offloaded to a background task within Intellij, but I'm not sure the correct way to achieve that at the moment.