### PR TITLE
Fixed handling of pubspec lines with comment.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,10 @@ repositories {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.61'
     compile 'com.google.code.gson:gson:2.8.6'
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.2'
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core-common:1.2.2'
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72'
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.6'
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core-common:1.3.6'
 }
 
 compileKotlin {

--- a/src/main/kotlin/pl/pszklarska/pubversionchecker/DependencyChecker.kt
+++ b/src/main/kotlin/pl/pszklarska/pubversionchecker/DependencyChecker.kt
@@ -13,9 +13,9 @@ class DependencyChecker {
     private val dependencyList = mutableListOf<Dependency>()
 
     fun getLatestVersion(dependency: String): String {
-        val packageName = dependency.trim().split(':')[0]
+        val packageName = dependency.getPackageName()
         val url = URL(PUB_API_URL + packageName)
-        printMessage("Checking latest version for: $packageName")
+        printMessage("Checking the latest version for: $packageName")
 
         val cachedDependency = dependencyList.find { it.packageName == packageName }
         if (cachedDependency != null) {

--- a/src/main/kotlin/pl/pszklarska/pubversionchecker/DependencyQuickFix.kt
+++ b/src/main/kotlin/pl/pszklarska/pubversionchecker/DependencyQuickFix.kt
@@ -8,7 +8,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.tree.IElementType
 
-
 class DependencyQuickFix(psiElement: PsiElement, private val latestVersion: String) :
     LocalQuickFixOnPsiElement(psiElement) {
     override fun getFamilyName(): String = "Update dependency"

--- a/src/test/kotlin/pl/pszklarska/pubversionchecker/FileParserTest.kt
+++ b/src/test/kotlin/pl/pszklarska/pubversionchecker/FileParserTest.kt
@@ -19,6 +19,7 @@ class FileParserTest {
         assertTrue("test:1.0.0+4".isPackageName())
         assertTrue("test:1.0.0+hotfix.oopsie".isPackageName())
         assertTrue("test:1.0.0-alpha.12".isPackageName())
+        assertTrue("test:1.0.0-alpha.12 # link.to.pub".isPackageName())
     }
 
     @Test
@@ -26,5 +27,4 @@ class FileParserTest {
         assertFalse("version:1.0.0".isPackageName())
         assertFalse("sdk: '>=2.0.0 <3.0.0'".isPackageName())
     }
-
 }


### PR DESCRIPTION
I've noticed that there is an issue when you have a comment in the pubspec like:
`bloc: ^4.0.0 #https://pub.dev/packages/bloc`
It was highlighting and replacing the comment rather than version number.
![bandicam 2020-05-17 18-42-12-289](https://user-images.githubusercontent.com/7517012/82154500-b5ac1680-986e-11ea-8761-08a5aa23400c.gif)

So I rewrote this part to use YAMLKeyValue rather than naive fetching PsiElement based on character count.
![bandicam 2020-05-17 18-38-22-286](https://user-images.githubusercontent.com/7517012/82154505-bcd32480-986e-11ea-95f7-313d97c7b902.gif)

Other than that, some libs update, typos, gardening