### PR TITLE
Prevent plugin crash when one dependency version cannot be fetched

### DIFF
--- a/src/main/kotlin/pl/pszklarska/pubversionchecker/FileParser.kt
+++ b/src/main/kotlin/pl/pszklarska/pubversionchecker/FileParser.kt
@@ -34,7 +34,15 @@ class FileParser(
         val problemDescriptionList = mutableListOf<VersionDescription>()
 
         val lines: List<VersionDescription> =
-            file.readPackageLines().map { async { mapToVersionDescription(it) } }.awaitAll()
+            file.readPackageLines().map {
+                async {
+                    try {
+                        mapToVersionDescription(it)
+                    } catch (e: UnableToGetLatestVersionException) {
+                        null
+                    }
+                }
+            }.awaitAll().filterNotNull()
 
         lines.forEach { versionDescription ->
             try {


### PR DESCRIPTION
When one dependency version cannot be fetched (e. g. when the dependency is not available anymore), then the plugin is crashing and is not showing update hints for any dependency.

Catching the thrown exception prevents this behaviour.